### PR TITLE
Get rid of hard-coded bootnodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2937,6 +2937,7 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
+ "hickory-resolver",
  "libp2p",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "splash"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "async-trait",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1.0"
 reqwest = { version = "0.11.23", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 warp = "0.3.6"
 bech32 = "0.9.1"
+hickory-resolver = "0.24.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splash"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Peer identities for bootnodes were previously hard-coded. This change removes the hard-coded bootnodes and instead uses all nodes returned from the DNS introducer.

This change also adds support for multiple `--known-peer` parameters.