### PR TITLE
Add testnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Options:
           Set listen address, defaults to all interfaces, use multiple times for multiple addresses
   -i, --identity-file <IDENTITY_FILE>
           Store and reuse peer identity (only useful for known peers)
+  -t, --testnet
+          Use Testnet (testnet11)
       --offer-hook <OFFER_HOOK>
           HTTP endpoint where incoming offers are posted to, sends JSON body {"offer":"offer1..."} (defaults to STDOUT)
       --listen-offer-submission <HOST:PORT>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Options:
   -i, --identity-file <IDENTITY_FILE>
           Store and reuse peer identity (only useful for known peers)
   -t, --testnet
-          Use Testnet (testnet11)
+          Use Testnet
       --offer-hook <OFFER_HOOK>
           HTTP endpoint where incoming offers are posted to, sends JSON body {"offer":"offer1..."} (defaults to STDOUT)
       --listen-offer-submission <HOST:PORT>

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -2,14 +2,16 @@ use hickory_resolver::{error::ResolveError, TokioAsyncResolver};
 use libp2p::Multiaddr;
 use std::str::FromStr;
 
-pub async fn resolve_peers_from_dns() -> Result<Vec<Multiaddr>, ResolveError> {
+pub async fn resolve_peers_from_dns(network_name: String) -> Result<Vec<Multiaddr>, ResolveError> {
     let (config, mut opts) = hickory_resolver::system_conf::read_system_conf()?;
 
     opts.edns0 = true;
     opts.try_tcp_on_error = true;
 
     let resolver = TokioAsyncResolver::tokio(config, opts);
-    let records = resolver.txt_lookup("_dnsaddr.splash.dexie.space.").await?;
+    let records = resolver
+        .txt_lookup(format!("_dnsaddr.{}.dexie.space.", network_name))
+        .await?;
 
     let peers: Vec<Multiaddr> = records
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ impl Splash {
     }
 
     pub fn with_testnet(mut self) -> Self {
-        self.network_name = "splash-testnet11".to_string();
+        self.network_name = "splash-testnet".to_string();
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub struct Splash {
     pub listen_addresses: Vec<Multiaddr>,
     pub known_peers: Vec<Multiaddr>,
     pub keys: identity::Keypair,
+    network_name: String,
     submission: Sender<Vec<u8>>,
     submission_receiver: Option<Receiver<Vec<u8>>>,
 }
@@ -53,6 +54,7 @@ impl Clone for Splash {
             listen_addresses: self.listen_addresses.clone(),
             known_peers: self.known_peers.clone(),
             keys: self.keys.clone(),
+            network_name: self.network_name.clone(),
             submission: self.submission.clone(),
             submission_receiver: None,
         }
@@ -74,6 +76,7 @@ impl Splash {
             known_peers: Vec::new(),
             listen_addresses: Vec::new(),
             keys: identity::Keypair::generate_ed25519(),
+            network_name: "splash".to_string(),
             submission: submission_sender,
             submission_receiver: Some(submission_receiver),
         }
@@ -119,12 +122,17 @@ impl Splash {
         self
     }
 
+    pub fn with_testnet(mut self) -> Self {
+        self.network_name = "splash-testnet11".to_string();
+        self
+    }
+
     pub async fn build(mut self) -> Result<SplashContext, Box<dyn std::error::Error>> {
         let (event_tx, event_rx) = mpsc::channel(100);
 
         // Check if known_peers is empty and resolve from DNS if necessary
         if self.known_peers.is_empty() {
-            self.known_peers = dns::resolve_peers_from_dns()
+            self.known_peers = dns::resolve_peers_from_dns(self.network_name.clone())
                 .await
                 .map_err(|e| format!("Failed to resolve peers from DNS: {}", e))?;
         }
@@ -161,7 +169,7 @@ impl Splash {
 
                 // Create a Kademlia behaviour.
                 let mut cfg = kad::Config::new(
-                    StreamProtocol::try_from_owned("/splash/kad/1".to_string())
+                    StreamProtocol::try_from_owned(format!("/{}/kad/1", self.network_name))
                         .expect("protocol name is valid"),
                 );
 
@@ -181,8 +189,11 @@ impl Splash {
                 kademlia.bootstrap().unwrap();
 
                 let identify = identify::Behaviour::new(
-                    identify::Config::new("/splash/id/1".into(), key.public().clone())
-                        .with_agent_version(format!("splash/{}", env!("CARGO_PKG_VERSION"))),
+                    identify::Config::new(
+                        format!("/{}/id/1", self.network_name),
+                        key.public().clone(),
+                    )
+                    .with_agent_version(format!("splash/{}", env!("CARGO_PKG_VERSION"))),
                 );
 
                 Ok(SplashBehaviour {
@@ -205,7 +216,7 @@ impl Splash {
         }
 
         // Create a Gossipsub topic
-        let topic = gossipsub::IdentTopic::new("/splash/offers/1");
+        let topic = gossipsub::IdentTopic::new(format!("/{}/offers/1", self.network_name));
 
         // subscribes to our topic
         swarm.behaviour_mut().gossipsub.subscribe(&topic)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ struct Opt {
     )]
     identity_file: Option<String>,
 
-    #[clap(long, short, help = "Use Testnet (testnet11)")]
+    #[clap(long, short, help = "Use Testnet")]
     testnet: bool,
 
     #[clap(
@@ -80,7 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if opt.testnet {
-        println!("Using Testnet (testnet11)");
+        println!("Using Testnet");
         splash = splash.with_testnet();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,9 @@ struct Opt {
     )]
     identity_file: Option<String>,
 
+    #[clap(long, short, help = "Use Testnet (testnet11)")]
+    testnet: bool,
+
     #[clap(
         long,
         help = "HTTP endpoint where incoming offers are posted to, sends JSON body {\"offer\":\"offer1...\"} (defaults to STDOUT)"
@@ -74,6 +77,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
     }) {
         splash = splash.with_keys(keypair);
+    }
+
+    if opt.testnet {
+        println!("Using Testnet (testnet11)");
+        splash = splash.with_testnet();
     }
 
     let SplashContext { node, mut events } = splash.build().await?;


### PR DESCRIPTION
Adding a new config flag `-t` or `--testnet` to run in testnet mode. This will request different initial peers from DNS and use different network identifiers for messages.