### PR TITLE
Privacy Enhancements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,9 +162,13 @@ impl Splash {
                     .build()
                     .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.
 
+                // Generate a dummy keypair for signing gossipsub messages
+                // TODO: use gossipsub::MessageAuthenticity::RandomAuthor and disable signing for even more privacy (once enough nodes are updated)
+                let dummy_key = identity::Keypair::generate_ed25519();
+
                 // build a gossipsub network behaviour
                 let gossipsub = gossipsub::Behaviour::new(
-                    gossipsub::MessageAuthenticity::RandomAuthor,
+                    gossipsub::MessageAuthenticity::Signed(dummy_key),
                     gossipsub_config,
                 )?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,12 +158,13 @@ impl Splash {
                     .message_id_fn(unique_offer_fn) // No duplicate offers will be propagated.
                     .max_transmit_size(MAX_OFFER_SIZE)
                     .validate_messages()
+                    .validation_mode(gossipsub::ValidationMode::Permissive)
                     .build()
                     .map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?; // Temporary hack because `build` does not return a proper `std::error::Error`.
 
                 // build a gossipsub network behaviour
                 let gossipsub = gossipsub::Behaviour::new(
-                    gossipsub::MessageAuthenticity::Signed(key.clone()),
+                    gossipsub::MessageAuthenticity::RandomAuthor,
                     gossipsub_config,
                 )?;
 


### PR DESCRIPTION
Sign messages using a randomly generated peer ID instead of our own, making it difficult to trace where an offer in the network originated.

Once enough nodes are updated to at least this version, we can use `gossipsub::MessageAuthenticity::RandomAuthor` to  disable origin signing for even more privacy.