### PR TITLE
Allow more offer prefixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ impl Splash {
             return Err(SplashError::OfferTooLarge(MAX_OFFER_SIZE));
         }
 
-        if !offer.starts_with("offer1") || bech32::decode(offer).is_err() {
+        if bech32::decode(offer).is_err() {
             return Err(SplashError::InvalidOfferFormat);
         }
 


### PR DESCRIPTION
New offer types, such as partial offers, use a new prefix (eg. `partial1...`). To support replicating them, I decided to remove the prefix string check completely. The bechm decoding should already be safe enough.

We could check the HRP when Splash parses offers in the future.